### PR TITLE
travis-ci issue resolved

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,19 @@
+language: python
+sudo: false
+
+# specify versions
+python:
+  - "3.2"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+
+# install dependencies 
+install: 
+  - "pip install -r requirements.txt"
+
+# run tests
+script: 
+  - pytest
+
+# check build at https://travis-ci.org/repositories


### PR DESCRIPTION
For activating Travis CI in naarad the metakgp admin needs to sign in to Travic CI and enable travis CI build for naarad repo. as mentioned [here](https://docs.travis-ci.com/user/for-beginners#To-get-started-with-Travis-CI%3A) in detail.
The change was made in response to https://github.com/metakgp/naarad-source/issues/54  issue.