### PR TITLE
Refactor fbscraper.py to remove facepy dependency

### DIFF
--- a/fbscraper.py
+++ b/fbscraper.py
@@ -18,7 +18,7 @@ with open('./ACCESS_TOKEN', 'r') as f:
 	access_token = f.readline().rstrip('\n')
 payload = {'access_token': access_token, 'limit': 2}
 
-s = requests.Session()
+req_session = requests.Session()
 
 
 def get_comments(post_id):
@@ -26,7 +26,7 @@ def get_comments(post_id):
 
 	# scrape the first page
 	print('scraping:', sub_url)
-	response = s.get(base_url + sub_url, params=payload)
+	response = req_session.get(base_url + sub_url, params=payload)
 	comments = json.loads(response.text)
 	data = comments['data']
 	return data
@@ -35,7 +35,7 @@ def get_comments(post_id):
 def get_picture(post_id, dir="."):
 	sub_url = post_id + '?fields=object_id'
 	try:
-		response = s.get(base_url + sub_url, params=payload)
+		response = req_session.get(base_url + sub_url, params=payload)
 		pic_obj = json.loads(response.text)
 		pic_id = pic_obj['object_id']
 	except KeyError:
@@ -43,7 +43,7 @@ def get_picture(post_id, dir="."):
 
 	try:
 		sub_url = pic_id + '?fields=images'
-		response = s.get(base_url + sub_url, params=payload)
+		response = req_session.get(base_url + sub_url, params=payload)
 		pic = json.loads(response.text)
 		return (pic['images'][0]['source'])
 		# f_name = "{}/{}.png".format(dir, pic_id)
@@ -58,13 +58,13 @@ def get_picture(post_id, dir="."):
 def get_event_picture(post_id, dir="."):
 	sub_url = post_id + '?fields=object_id'
 	try:
-		response = s.get(base_url + sub_url, params=payload)
+		response = req_session.get(base_url + sub_url, params=payload)
 		pic_id = json.loads(response.text)['object_id']
 	except KeyError:
 		return None
 	try:
 		sub_url = pic_id + '?fields=cover'
-		response = s.get(base_url + sub_url, params=payload)
+		response = req_session.get(base_url + sub_url, params=payload)
 		pic = json.loads(response.text)
 		return (pic['cover']['source'])
 		# urllib.request.urlretrieve(pic['cover']['source'] , "{}/{}.png".format(dir, pic_id))
@@ -77,7 +77,7 @@ def get_link(post_id):
 	sub_url = post_id + '?fields=link'
 
 	try:
-		response = s.get(base_url + sub_url, params=payload)
+		response = req_session.get(base_url + sub_url, params=payload)
 		pic = json.loads(response.text)
 		link = pic['link']
 	except KeyError:
@@ -88,7 +88,7 @@ def get_link(post_id):
 
 def get_event(post_id, page_id):
 	sub_url = page_id + '/events'
-	response = s.get(base_url + sub_url, params=payload)
+	response = req_session.get(base_url + sub_url, params=payload)
 	all_events = json.loads(response.text)
 
 	message = """
@@ -118,13 +118,13 @@ def get_shared_post(post_id):
 	sub_url = post_id + '?fields=parent_id'
 	# getting id of the original post
 	try :	
-		response = s.get(base_url + sub_url, params=payload)
+		response = req_session.get(base_url + sub_url, params=payload)
 		parent_id = json.loads(response.text)['parent_id']
 		query = parent_id + '?fields=message'
 	except KeyError :
 		query = post_id + '?fields=message'
 	try :
-		response = s.get(base_url + query, params=payload)
+		response = req_session.get(base_url + query, params=payload)
 		original_message = json.loads(response.text)['message']
 	except KeyError :
 		original_message = ""
@@ -134,13 +134,13 @@ def get_video(post_id) :
 	video_id = post_id.split('_')[1]
 	sub_url = video_id + "?fields=embeddable"
 	try : 
-		response = s.get(base_url + sub_url, params=payload)
+		response = req_session.get(base_url + sub_url, params=payload)
 		embed_flag = json.loads(response.text)['embeddable']
 	except KeyError:
 		return ""
 	if embed_flag : #checking if the video is embedddable 
 		embed_html_url=video_id + '?fields=from,source'
-		response = s.get(base_url + embed_html_url, params=payload)
+		response = req_session.get(base_url + embed_html_url, params=payload)
 		query = json.loads(response.text)
 		video_url = query['source']
 		page_name = query['from']['name']
@@ -165,7 +165,7 @@ def get_feed(page_id, pages=10):
 
 	# scrape the first page
 	print('scraping:', sub_url)
-	response = s.get(base_url + sub_url, params=payload)
+	response = req_session.get(base_url + sub_url, params=payload)
 	feed = json.loads(response.text)
 	new_page_data = feed['data']
 
@@ -188,7 +188,7 @@ def get_feed(page_id, pages=10):
 		sub_url = page_id + '/feed?' + the_until_arg
 		print('baking:', sub_url)
 		try:
-			response = s.get(base_url + sub_url, params=payload)
+			response = req_session.get(base_url + sub_url, params=payload)
 			feed = json.loads(response.text)
 			new_page_data = feed['data']
 			is_new_post = (

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,25 +1,5 @@
 commonregex==1.5.4
 Django==1.9.1
-django-frontend==1.8.0
-django-utils==0.0.2
-encoding==1.0.0
--e git+https://github.com/hargup/facepy@0b2c15586028bead5f17be9ec8fce63b0910273c#egg=facepy
-httplib2==0.9.2
 Jinja2==2.8
-keyring==9.3.1
-MarkupSafe==0.23
-oauth2client==3.0.0
-pyasn1==0.1.9
-pyasn1-modules==0.0.8
-python-dateutil==2.5.3
-pytz==2016.6.1
 requests==2.10.0
-rsa==3.4.2
-simplejson==3.8.2
-six==1.10.0
-uritemplate==0.6
-urllib2-file==0.2.1
-urllib2-prior-auth==0.2.0
-urllib3==1.16
-utils==0.9.0
-wheel==0.26.0
+python_dateutil==2.6.0


### PR DESCRIPTION
facepy's fork that has been in active use in naarad has not been updated
in a while, and falls way behind vanilla Graph API in terms of
functionality as well as documentation. Directly interfacing with the
Graph API makes it easier to work with the API, and helps keeping the
code simple enough for future contributors by not adding another
abstraction layer in the middle.

Notes:

  - Regenerated requirements.txt using 'pipreqs' (Please do check if the
  list is exhaustive)
  - [WIP] Cleaned up code to be more in sync with PEP 8 style guide